### PR TITLE
igb_uio: legacy pci_dma_set_mask & co. removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Makefile & Kbuild file for building installing the igb_uio.ko driver
 # options make, make install, make clean ...
 
-IGB_UIO_VERSION ?= weka1.0.1
+IGB_UIO_VERSION ?= weka1.0.2
 
 #default is to compile against the running kernel (kernel-devel installed on the system)
 # do 'make KERNEL_PATH=/home/user/my_kernel_path/ to compile against an alternative path

--- a/igb_uio.c
+++ b/igb_uio.c
@@ -10,6 +10,7 @@
 
 #include <linux/device.h>
 #include <linux/module.h>
+#include <linux/dma-mapping.h>
 #include <linux/pci.h>
 #include <linux/uio_driver.h>
 #include <linux/io.h>
@@ -504,15 +505,15 @@ igbuio_pci_probe(struct pci_dev *dev, const struct pci_device_id *id)
 		goto fail_release_iomem;
 
 	/* set 64-bit DMA mask */
-	err = pci_set_dma_mask(dev,  DMA_BIT_MASK(64));
+	err = dma_set_mask(&dev->dev, DMA_BIT_MASK(64));
 	if (err != 0) {
 		dev_err(&dev->dev, "Cannot set DMA mask\n");
 		goto fail_release_iomem;
 	}
 
-	err = pci_set_consistent_dma_mask(dev, DMA_BIT_MASK(64));
+	err = dma_set_coherent_mask(&dev->dev, DMA_BIT_MASK(64));
 	if (err != 0) {
-		dev_err(&dev->dev, "Cannot set consistent DMA mask\n");
+		dev_err(&dev->dev, "Cannot set coherent DMA mask\n");
 		goto fail_release_iomem;
 	}
 


### PR DESCRIPTION
The legacy compatibility wrappers were removed in kernel 5.18.

I will probably need to cherry-pick this into the LTS tree as well.